### PR TITLE
Update dependabot configuration to use uv package ecosystem

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -1,6 +1,7 @@
 version: 2
+
 updates:
-  - package-ecosystem: "pip"
+  - package-ecosystem: "uv"
     directory: "/"
     schedule:
       interval: "weekly"


### PR DESCRIPTION
# Summary
**Title:** Update dependabot configuration to use uv package ecosystem

Reviewers: miguelcsilva

## Description
Updated the dependabot configuration to use the "uv" package ecosystem instead of "pip" to properly support UV dependency management.

## Changes
- Changed package-ecosystem from "pip" to "uv" in `.github/dependabot.yaml`
- Added proper formatting with blank line for YAML readability

## Additional Notes
This ensures dependabot will correctly detect and update dependencies managed by UV, the modern Python package and project manager used in this project.

🤖 Generated with [Claude Code](https://claude.ai/code)